### PR TITLE
Update on default nonlinearity

### DIFF
--- a/cifar10-densenet.py
+++ b/cifar10-densenet.py
@@ -57,7 +57,7 @@ class Model(ModelDesc):
             with tf.variable_scope(name) as scope:
                 l = BatchNorm('bn1', l)
                 l = tf.nn.relu(l)
-                l = Conv2D('conv1', l, in_channel, 1, stride=1, use_bias=False)
+                l = Conv2D('conv1', l, in_channel, 1, stride=1, use_bias=False, nl=tf.nn.relu)
                 l = AvgPooling('pool', l, 2)
             return l
 


### PR DESCRIPTION
I found the design of having the default nonlinearity to tf.nn.relu in tensorpack can be confusing to people,  and now there is `argscope` to set default options for layers. I'm going to change the default to tf.identity in the future.
