### PR TITLE
remove one unnecessary line

### DIFF
--- a/cifar10-densenet.py
+++ b/cifar10-densenet.py
@@ -95,7 +95,6 @@ class Model(ModelDesc):
         cost = tf.reduce_mean(cost, name='cross_entropy_loss')
 
         wrong = prediction_incorrect(logits, label)
-        nr_wrong = tf.reduce_sum(wrong, name='wrong')
         # monitor training error
         add_moving_summary(tf.reduce_mean(wrong, name='train_error'))
 


### PR DESCRIPTION
With updated tensorpack, this line is not needed anymore. `ClassificationError` would now directly look for the output of `prediction_incorrect` to compute the error.